### PR TITLE
micro: increase micro_write buffer size and add assert

### DIFF
--- a/micro.h
+++ b/micro.h
@@ -61,7 +61,7 @@ int micro_write32_swap(int fd, int addr, uint32_t *data);
 uint8_t micro_scaps_remaining_pct(int i2cfd, board_t *board);
 void micro_generic_info(int i2cfd, board_t *board);
 
-void micro_sleep(int i2cfd, board_t *board, uint32_t ms);
+void micro_sleep(int i2cfd, board_t *board, uint32_t seconds);
 void micro_set_charge_current(int i2cfd, board_t *board, uint16_t ma);
 void micro_scaps_en(int i2cfd, board_t *board, int en);
 void micro_scaps_block_pct(int i2cfd, board_t *board, int pct);

--- a/tsmicroctl.c
+++ b/tsmicroctl.c
@@ -17,6 +17,25 @@
 #include "ts7180.h"
 #include "ts7800v2.h"
 
+/* Currently, all supported platforms, luckily, have the microcontroller on
+ * I2C bus 0, and are at chip address 0x54. Because of that, we can still
+ * get limited communication to the microcontroller when the exact model of the
+ * current platform cannot be determined. This allows us, for example, to issue
+ * a sleep command even if /sys is not mounted.
+ */
+board_t generic_board = {
+	.compatible = "",
+	.i2c_bus = 0,
+	.i2c_chip = 0x54,
+	.info_function = NULL,
+	.has_silo = 0,
+	.power_fail_active = 0,
+	.power_fail_bank = "",
+	.power_fail_io = 0,
+	.max_current = 0,
+	.min_current = 0,
+};
+
 void usage(char **argv, board_t *board)
 {
 	fprintf(stderr,
@@ -51,7 +70,23 @@ board_t *get_board()
 	file = fopen("/sys/firmware/devicetree/base/compatible", "r");
 	if (!file) {
 		perror("Unable to open /sys/firmware/devicetree/base/compatible");
-		return NULL;
+		/* NOTE WELL!
+		 * When attempting to issue a sleep command at the last possible
+		 * moment on a booted system, it is completely valid to have /sys
+		 * NOT be mounted when we're called. Because of this, this will
+		 * result in errno being ENOENT. In this case, we're going to just
+		 * guess that we still want to run.
+		 */
+		if (errno == ENOENT) {
+			fprintf(stderr, "\nPlatform could not be detected!\n\n" \
+					"This is likely because /sys is not properly " \
+					"mounted. The only command that will be " \
+					"accepted in this situation is -s/--sleep." \
+					"\n\n");
+			return &generic_board;
+		} else {
+			return NULL;
+		}
 	}
 
 	if (fgets(comp, sizeof(comp), file) == NULL) {
@@ -83,6 +118,7 @@ int main(int argc, char *argv[])
 	int opt_info = 0;
 	int opt_current = -1;
 	int opt_sleep = -1;
+	int opt_nonsleep_opt = 0;
 
 	board = get_board();
 	if (board == NULL) {
@@ -109,21 +145,27 @@ int main(int argc, char *argv[])
 		switch (c) {
 		case 'e':
 			opt_enable = 1;
+			opt_nonsleep_opt = 1;
 			break;
 		case 'd':
 			opt_disable = 1;
+			opt_nonsleep_opt = 1;
 			break;
 		case 'w':
 			opt_wait_pct = atoi(optarg);
+			opt_nonsleep_opt = 1;
 			break;
 		case 'b':
 			opt_daemon_pct = atoi(optarg);
+			opt_nonsleep_opt = 1;
 			break;
 		case 'i':
 			opt_info = 1;
+			opt_nonsleep_opt = 1;
 			break;
 		case 'c':
 			opt_current = atoi(optarg);
+			opt_nonsleep_opt = 1;
 			break;
 		case 's':
 			opt_sleep = atoi(optarg);
@@ -137,6 +179,18 @@ int main(int argc, char *argv[])
 			usage(argv, board);
 			return 1;
 		}
+	}
+
+	/* If we had to fall back to the generic_board struct, we need to only
+	 * allow opt_sleep to be processed. Any other flags/options are not
+	 * guaranteed to correctly run in this case.
+	 */
+	if (board == &generic_board && opt_nonsleep_opt) {
+		fprintf(stderr, "Only -s/--sleep is allowed to be issued when " \
+				"the platform is not able to correctly be recognized " \
+				"due to /sys not being available or not able to be " \
+				"opened.\n");
+		return 1;
 	}
 
 	i2cfd = micro_init(board->i2c_bus, board->i2c_chip);


### PR DESCRIPTION
Allow for more arbitrarily long messages, but still limited to a previously tested and found length limitation for a single message.

Tested in latest Buildroot-ts.git on TS-7100-Z